### PR TITLE
typings for typeScript projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,3 +122,16 @@ i18next
     // ...
   });
 ```
+
+## If You use typescript##
+You can find typings file in `/typings` folder.
+> in order to comply with some neat project structure You would copy `i18next-xhr-backend.d.ts` file from `typings/*.d.ts` to some other folder, e.g. `/customTypings`
+
+The next step - to give the compiler know about your  `*.d.ts` files. Add the following section to your `tsconfig.json` file.
+```javascript
+//...some configuration code
+"filesGlob": [
+    "./your_custom_typings_folder_path/**/*.d.ts"
+  ],
+//...some configuration code
+```

--- a/typings/i18next-xhr-backend.d.ts
+++ b/typings/i18next-xhr-backend.d.ts
@@ -1,0 +1,41 @@
+// declare module 'i18next-xhr-backend' {
+//     export class Backend {
+//         type: any;
+//         services: any;
+//         options: any;
+//         constructor(services: any, options?: {});
+//         init(services: any, options?: {}): void;
+//         readMulti(languages: any, namespaces: any, callback: any): void;
+//         read(language: any, namespace: any, callback: any): void;
+//         loadUrl(url: any, callback: any): void;
+//         create(languages: any, namespace: any, key: any, fallbackValue: any): void;
+//     }
+//
+// }
+declare module 'i18next-xhr-backend' {
+
+    interface Interpolator {
+        interpolate: () => string
+    }
+    interface Services {
+        interpolator: Interpolator
+    }
+    export class Backend {
+        type: 'backend';
+        services: Services;
+        options: {
+            loadPath: string,
+            addPath:  string,
+            allowMultiLoading: boolean,
+            parse: () => {},
+            crossDomain: boolean,
+            ajax: () => void
+        };
+        constructor(services: Services, options?: {});
+        init(services: Services, options?: {}): void;
+        readMulti(languages: any[], namespaces: any[], callback: () => void): void;
+        read(language: {}, namespace: {}, callback: () => void): void;
+        loadUrl(url: string, callback: () => void): void;
+        create(languages: any[], namespace: string, key: string, fallbackValue: string): void;
+    }
+}


### PR DESCRIPTION
Hi, @jamuhl!

First of all i would say that this plugin is very useful. Tnx for it!
But recently i have started to use your 18next-xhr-beckend plugin for i18next in some typescript project. And during typescript compilation process i have seen such error:
```javascript
"/yourHost/pathToApp/pathToFile/filename.ts(3,26): Cannot find module 'i18next-xhr-backend'."
```

So, I would suggest a little fix for this issue. But can You check my *.d.ts file? May i miss something?