### PR TITLE
Only set application/x-www-form-urlencoded if POST request

### DIFF
--- a/i18nextXHRBackend.js
+++ b/i18nextXHRBackend.js
@@ -70,7 +70,9 @@
       if (!options.crossDomain) {
         x.setRequestHeader('X-Requested-With', 'XMLHttpRequest');
       }
-      x.setRequestHeader('Content-type', 'application/x-www-form-urlencoded');
+      if (data) {
+        x.setRequestHeader('Content-type', 'application/x-www-form-urlencoded');
+      }
       x.onreadystatechange = function () {
         x.readyState > 3 && callback && callback(x.responseText, x);
       };

--- a/src/index.js
+++ b/src/index.js
@@ -17,7 +17,9 @@ function ajax(url, options, callback, data, cache) {
     if (!options.crossDomain) {
       x.setRequestHeader('X-Requested-With', 'XMLHttpRequest');
     }
-    x.setRequestHeader('Content-type', 'application/x-www-form-urlencoded');
+    if (data) {
+      x.setRequestHeader('Content-type', 'application/x-www-form-urlencoded');
+    }
     x.onreadystatechange = function() {
       x.readyState > 3 && callback && callback(x.responseText, x);
     };


### PR DESCRIPTION
I discovered an issue where Werkzeug web server would hang. The reason came back to `i18next-xhr-backend` setting the `Content-Type` header to `application/x-www-form-urlencoded` on ANY request.

This PR only sets this header when a POST request is made.