### PR TITLE
Mark Backend class as export default

### DIFF
--- a/typings/i18next-xhr-backend.d.ts
+++ b/typings/i18next-xhr-backend.d.ts
@@ -20,7 +20,7 @@ declare module 'i18next-xhr-backend' {
     interface Services {
         interpolator: Interpolator
     }
-    export class Backend {
+    export default class Backend {
         type: 'backend';
         services: Services;
         options: {


### PR DESCRIPTION
This fixes the error `Module 'i18next-xhr-backend' has no default export` when importing the Backend class.