### PR TITLE
check status code range using >= && <

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -97,9 +97,8 @@ class Backend {
 
   loadUrl(url, callback) {
     this.options.ajax(url, this.options, (data, xhr) => {
-      const statusCode = xhr.status.toString();
-      if (statusCode.indexOf('5') === 0) return callback('failed loading ' + url, true /* retry */);
-      if (statusCode.indexOf('4') === 0) return callback('failed loading ' + url, false /* no retry */);
+      if (xhr.status >= 500 && xhr.status < 600) return callback('failed loading ' + url, true /* retry */);
+      if (xhr.status >= 400 && xhr.status < 500) return callback('failed loading ' + url, false /* no retry */);
 
       let ret, err;
       try {


### PR DESCRIPTION
Check status code range using the correct numeric operators instead of string search.

Comparing numbers by converting them into strings and then doing string search of certain digits on that string makes me wonder if I should refrain from using this library.