### PR TITLE
AMD export should not be named

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -26,6 +26,6 @@ export default {
     npm({ jsnext: true })
   ].concat(compress ? uglify() : []),
   moduleName: 'i18nextXHRBackend',
-  moduleId: 'i18nextXHRBackend',
+  // moduleId: 'i18nextXHRBackend',
   dest
 };


### PR DESCRIPTION
The AMD export should not be named (because that's not how AMD is meant to work and it causes many problems).

In other words, line 3 of the build file is:

```javascript 
typeof define === 'function' && define.amd ? define('i18nextXHRBackend', factory) :
```

But it should be:

```javascript
typeof define === 'function' && define.amd ? define(factory) :
```

This issue was [apparently resolved in version 3.0.0 of i18next](https://github.com/i18next/i18next/blob/master/CHANGELOG.md#300) but never fixed in the i18next-xhr-backend plugin.

Note that this is not a backwards compatible change.

