### PR TITLE
Add GitHub repository URL to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,10 @@
   ],
   "homepage": "https://github.com/i18next/i18next-xhr-backend",
   "bugs": "https://github.com/i18next/i18next-xhr-backend/issues",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/i18next/i18next-xhr-backend"
+  },
   "dependencies": {},
   "devDependencies": {
     "babel-cli": "6.11.4",


### PR DESCRIPTION
If you go to this [NPM package page](http://npmjs.com/package/i18next-xhr-backend) you'll notice that there is no link to this repository which can confuse people that wanted to look at the code.

This can be fixed by adding the repository information in the `package.json` file.