### PR TITLE
Update TypeScript definitions installation documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,10 +132,12 @@ i18next
   });
 ```
 
-## If You use typescript##
-You can find typings file on `DefinitelyTyped`
+## TypeScript definitions
 
-The next step - install the typings with
-```
-typings install --save --global dt~i18next-xhr-backend
-```
+- Install from `@types` (for TypeScript v2 and later):
+
+        npm install --save-dev @types/i18next-xhr-backend
+
+- Install from `typings`:
+
+        typings install --save --global dt~i18next-xhr-backend


### PR DESCRIPTION
`typings` is for older versions of TypeScript, and I'm not even sure they're maintained anymore. [@types](https://www.npmjs.com/~types) is the preferred location for getting ts definitions<sup>[1](https://blogs.msdn.microsoft.com/typescript/2016/06/15/the-future-of-declaration-files/)</sup>, beginning with v1.8 and official with v2. I've verified that the same types are available from the \@types repo, and updated the docs to help users install them from that source. 💯 