### PR TITLE
fix(src) MSXML2.XMLHTTP.3.0 only use ActiveXObject

### DIFF
--- a/src/ajax.js
+++ b/src/ajax.js
@@ -21,11 +21,11 @@ function addQueryString(url, params) {
 
 // https://gist.github.com/Xeoncross/7663273
 function ajax(url, options, callback, data, cache) {
-  
+
   if (data && typeof data === 'object') {
     if (!cache) {
       data['_t'] = new Date();
-    } 
+    }
     // URL encoded form data must be in querystring format
     data = addQueryString('', data).slice(1);
   }
@@ -35,7 +35,12 @@ function ajax(url, options, callback, data, cache) {
   }
 
   try {
-    var x = new (XMLHttpRequest || ActiveXObject)('MSXML2.XMLHTTP.3.0');
+    var x
+    if (XMLHttpRequest) {
+      x = new XMLHttpRequest();
+    } else {
+      x = new ActiveXObject('MSXML2.XMLHTTP.3.0');
+    }
     x.open(data ? 'POST' : 'GET', url, 1);
     if (!options.crossDomain) {
       x.setRequestHeader('X-Requested-With', 'XMLHttpRequest');


### PR DESCRIPTION
# Error

An error occurs when using jsdom and sinonjs.

- TypeError: Cannot create property 'logger' on string 'MSXML2.XMLHTTP.3.0'

```js
import { useFakeXMLHttpRequest } from 'sinon'
global.XMLHttpRequest = useFakeXMLHttpRequest()
```

related issue: 
- https://github.com/sinonjs/sinon/issues/826#issuecomment-292062009
- https://msdn.microsoft.com/en-us/library/ms535874(v=vs.85).aspx