### PR TITLE
Additional explanation for MultiLoading

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,15 @@ i18next
 
   // your backend server supports multiloading
   // /locales/resources.json?lng=de+en&ns=ns1+ns2
+  // Adapter is needed to enable MultiLoading https://github.com/i18next/i18next-multiload-backend-adapter
+  // Returned JSON structure in this case is
+  // {
+  //  lang : {
+  //   namespaceA: {},
+  //   namespaceB: {},
+  //   ...etc
+  //  }
+  // }
   allowMultiLoading: false, // set loadPath: '/locales/resources.json?lng={{lng}}&ns={{ns}}' to adapt to multiLoading
 
   // parse data after it has been fetched


### PR DESCRIPTION
It's not very clear how to enable MultiLoading for loading multiple namespaces at once. Judging by the docs it's enough to enable the flag `allowMultiLoading` but that alone does not work since an adapter is necessary.

Also it's not very clear what JSON return format is required to the translations to be applied. By default the backend plugin will fetch namespace-by-namespace, and whatever JSON is returned from the server will be applied for that namespace.

I hope this PR can clarify these points a bit :) 