### PR TITLE
customHeaders function

### DIFF
--- a/src/ajax.js
+++ b/src/ajax.js
@@ -53,6 +53,7 @@ function ajax(url, options, callback, data, cache) {
       x.overrideMimeType("application/json");
     }
     var h = options.customHeaders;
+    h = typeof h === 'function' ? h() : h;
     if (h) {
       for (var i in h) {
         x.setRequestHeader(i, h[i]);


### PR DESCRIPTION
Allow options headers to be a function to retrieve dynamic headers.  Could extend to pass in some context that's useful for understanding headers required for the given request..  Fixes auth header issue as per #301