### PR TITLE
add `use()` tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "dtslint": "^0.9.0",
     "eslint": "6.1.0",
     "eslint-config-airbnb": "17.1.1",
-    "i18next": "^17.0.8",
+    "i18next": "^17.0.9",
     "istanbul": "gotwarlost/istanbul#source-map",
     "json5": "2.1.0",
     "karma": "4.2.0",

--- a/test/typescript/i18next-xhr-backend.ts
+++ b/test/typescript/i18next-xhr-backend.ts
@@ -1,20 +1,15 @@
-import XHR, { AjaxRequestCallback, BackendOptions } from "i18next-xhr-backend";
-import { Resource } from "i18next";
+import XHR, { AjaxRequestCallback, BackendOptions } from 'i18next-xhr-backend';
+import * as i18n from 'i18next';
 
 const options: BackendOptions = {
-  loadPath: "/locales/{{lng}}/{{ns}}.json",
-  addPath: "locales/add/{{lng}}/{{ns}}",
+  loadPath: '/locales/{{lng}}/{{ns}}.json',
+  addPath: 'locales/add/{{lng}}/{{ns}}',
   allowMultiLoading: false,
-  parse: (data: string) => data.replace(/a/g, ""),
+  parse: (data: string) => data.replace(/a/g, ''),
   crossDomain: false,
   withCredentials: false,
-  ajax: (
-    url: string,
-    options: BackendOptions,
-    callback: AjaxRequestCallback,
-    data: {}
-  ) => {},
-  queryStringParams: { v: "1.3.5" }
+  ajax: (url: string, options: BackendOptions, callback: AjaxRequestCallback, data: {}) => {},
+  queryStringParams: { v: '1.3.5' },
 };
 
 const xhr = new XHR();
@@ -22,12 +17,14 @@ xhr.init(options);
 const xhr2 = new XHR(null, options);
 const type: string = xhr.type;
 const newOptions: BackendOptions = xhr.options;
-xhr.create("en", "ns", "key", "value");
-xhr.create(["en", "us"], "ns", "key", "value");
-xhr.read("en", "ns", (err: Error | null | undefined, data: Resource) => {});
-xhr.readMulti(
-  ["en"],
-  ["ns"],
-  (err: Error | null | undefined, data: Resource) => {}
-);
-xhr.loadUrl("someurl", (err: Error | null | undefined, data: Resource) => {});
+xhr.create('en', 'ns', 'key', 'value');
+xhr.create(['en', 'us'], 'ns', 'key', 'value');
+xhr.read('en', 'ns', (err: Error | null | undefined, data: i18n.Resource) => {});
+xhr.readMulti(['en'], ['ns'], (err: Error | null | undefined, data: i18n.Resource) => {});
+xhr.loadUrl('someurl', (err: Error | null | undefined, data: i18n.Resource) => {});
+
+// instance
+i18n.use(xhr);
+
+// class
+i18n.use(XHR);


### PR DESCRIPTION
Closes #320

I thought this was confirmed fixed by #319, but it appears the previously created typescript tests were actually not exercising the `.use(XHR)`.

This shows we need a types change upstream.  Depends on release of https://github.com/i18next/i18next/pull/1301